### PR TITLE
Make the plugin macro-friendly

### DIFF
--- a/src/main/java/Vaa3d_Writer.java
+++ b/src/main/java/Vaa3d_Writer.java
@@ -190,7 +190,7 @@ public class Vaa3d_Writer implements PlugIn {
             }
 
             out.close();
-            IJ.showMessage("file saved");
+            IJ.showStatus("Saved " + path);
 
         } catch (Exception e) {
             IJ.error("Error:" + e.toString());


### PR DESCRIPTION
It is not very nice to ask the user to click the "OK" button after every
file when batch-converting image files to .v3draw format. So let's just
not do that, but update the status instead.

Signed-off-by: Johannes Schindelin johannes.schindelin@gmx.de
